### PR TITLE
Add version key 🗝

### DIFF
--- a/custom_components/combined/manifest.json
+++ b/custom_components/combined/manifest.json
@@ -6,5 +6,6 @@
   "codeowners": [
     "@ludeeus"
   ],
-  "requirements": []
+  "requirements": [],
+  "version": "0.1.0"
 }


### PR DESCRIPTION
Version key required from HA Core 2021.6 onwards